### PR TITLE
feat: interactive debug builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .*.swp
 .DS_Store
 thumbs.db
+bin/
 
 # local repository customization
 .envrc

--- a/Dockerfile.fail
+++ b/Dockerfile.fail
@@ -1,0 +1,2 @@
+FROM ubuntu
+RUN touch /opt/i-should-not-exist && false && not-a-command

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,2 @@
+FROM ubuntu
+RUN apt-get update && apt-get install -y git && apt-get clean

--- a/Makefile
+++ b/Makefile
@@ -188,6 +188,11 @@ bundles:
 .PHONY: clean
 clean: clean-cache
 
+.PHONY: interactive
+interactive: # An interactive build option that will not fail on error of a layer
+	mkdir -p ./bin
+	go build -o ./bin/docker-build main.go
+
 .PHONY: clean-cache
 clean-cache: ## remove the docker volumes that are used for caching in the dev-container
 	docker volume rm -f docker-dev-cache docker-mod-cache

--- a/api/server/backend/build/backend.go
+++ b/api/server/backend/build/backend.go
@@ -59,18 +59,19 @@ func (b *Backend) Build(ctx context.Context, config backend.BuildConfig) (string
 		return "", err
 	}
 
+	// buildkit pings another grpc, so I am disabling for now
 	var build *builder.Result
-	if useBuildKit {
+	/*if useBuildKit {
 		build, err = b.buildkit.Build(ctx, config)
 		if err != nil {
 			return "", err
 		}
-	} else {
-		build, err = b.builder.Build(ctx, config)
-		if err != nil {
-			return "", err
-		}
+	} else {*/
+	build, err = b.builder.Build(ctx, config)
+	if err != nil {
+		return "", err
 	}
+	//	}
 
 	if build == nil {
 		return "", nil

--- a/api/server/router/build/build_routes.go
+++ b/api/server/router/build/build_routes.go
@@ -38,6 +38,7 @@ func newImageBuildOptions(ctx context.Context, r *http.Request) (*types.ImageBui
 	options := &types.ImageBuildOptions{
 		Version:        types.BuilderV1, // Builder V1 is the default, but can be overridden
 		Dockerfile:     r.FormValue("dockerfile"),
+		Interactive:    httputils.BoolValue(r, "interactive"),
 		SuppressOutput: httputils.BoolValue(r, "q"),
 		NoCache:        httputils.BoolValue(r, "nocache"),
 		ForceRemove:    httputils.BoolValue(r, "forcerm"),

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -61,19 +61,22 @@ type ImageBuildOptions struct {
 	Remove         bool
 	ForceRemove    bool
 	PullParent     bool
-	Isolation      container.Isolation
-	CPUSetCPUs     string
-	CPUSetMems     string
-	CPUShares      int64
-	CPUQuota       int64
-	CPUPeriod      int64
-	Memory         int64
-	MemorySwap     int64
-	CgroupParent   string
-	NetworkMode    string
-	ShmSize        int64
-	Dockerfile     string
-	Ulimits        []*container.Ulimit
+
+	// Enable interactive debug build
+	Interactive  bool
+	Isolation    container.Isolation
+	CPUSetCPUs   string
+	CPUSetMems   string
+	CPUShares    int64
+	CPUQuota     int64
+	CPUPeriod    int64
+	Memory       int64
+	MemorySwap   int64
+	CgroupParent string
+	NetworkMode  string
+	ShmSize      int64
+	Dockerfile   string
+	Ulimits      []*container.Ulimit
 	// BuildArgs needs to be a *string instead of just a string so that
 	// we can tell the difference between "" (empty string) and no value
 	// at all (nil). See the parsing of buildArgs in

--- a/client/image_build.go
+++ b/client/image_build.go
@@ -76,6 +76,11 @@ func (cli *Client) imageBuildOptionsToQuery(ctx context.Context, options types.I
 		query.Set("forcerm", "1")
 	}
 
+	// Interactive debug build (don't fail but return early)
+	if options.Interactive {
+		query.Set("interactive", "1")
+	}
+
 	if options.PullParent {
 		query.Set("pull", "1")
 	}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
+	"github.com/docker/docker/pkg/archive"
+	"github.com/docker/docker/pkg/jsonmessage"
+)
+
+// This should be run in the .devcontainer environment, and following the instructions
+// here: https://github.com/moby/moby/blob/master/docs/contributing/set-up-dev-env.md
+// to build and start the daemon:
+
+// In one terminal (this builds and starts the daemon)
+// hack/make.sh binary install-binary run
+
+// In another terminal:
+// make interactive
+// This will work
+// ./bin/docker-build -t test -f Dockerfile.test .
+
+// This will fail
+// ./bin/docker-build -t fail -f Dockerfile.fail .
+
+// But with interactive -i, it will work!
+// ./bin/docker-build -i -t works -f Dockerfile.fail .
+
+// copyFile copies a file from a source to a destination
+func copyFile(src, dest string) {
+	sourceFile, err := os.Open(src)
+	if err != nil {
+		panic(err)
+	}
+	defer sourceFile.Close()
+
+	destinationFile, err := os.Create(dest)
+	if err != nil {
+		panic(err)
+	}
+	defer destinationFile.Close()
+
+	_, err = io.Copy(destinationFile, sourceFile)
+	if err != nil {
+		panic(err)
+	}
+}
+
+// GetImageIDFromBody reads the image ID from the build response body.
+func GetImageIDFromBody(body io.Reader) string {
+	var (
+		jm  jsonmessage.JSONMessage
+		br  types.BuildResult
+		dec = json.NewDecoder(body)
+	)
+	for {
+		err := dec.Decode(&jm)
+		if err == io.EOF {
+			break
+		}
+		if jm.Aux == nil {
+			continue
+		}
+		json.Unmarshal(*jm.Aux, &br)
+		break
+	}
+	io.Copy(io.Discard, body)
+	return br.ID
+}
+
+func main() {
+
+	target := flag.String("t", "", "Build target")
+	dockerfile := flag.String("f", "Dockerfile", "Dockerfile path")
+	interactiveDebug := flag.Bool("i", false, "interactive debug build")
+
+	flag.Parse()
+	args := flag.Args()
+
+	if *target == "" {
+		log.Panicf("Please enter a -t target to build")
+	}
+	buildContext := "."
+	if len(args) > 0 {
+		buildContext = args[0]
+	}
+	fmt.Println("🦎 Dinosaur debug builder:")
+	fmt.Println("  interactive debug:", *interactiveDebug)
+	fmt.Println("         dockerfile:", *dockerfile)
+	fmt.Println("            context:", buildContext)
+	fmt.Println("             target:", *target)
+
+	apiClient, err := client.NewClientWithOpts(client.FromEnv)
+	if err != nil {
+		panic(err)
+	}
+	defer apiClient.Close()
+
+	// Create temporary directory for reader (context)
+	// We will copy dockerfile there
+	tmp, err := os.MkdirTemp("", "docker-dinosaur-build")
+	if err != nil {
+		log.Fatalf("could not create temporary directory: %v", err)
+	}
+	defer os.RemoveAll(tmp)
+
+	copyFile(*dockerfile, filepath.Join(tmp, "Dockerfile"))
+	reader, err := archive.TarWithOptions(tmp, &archive.TarOptions{})
+	if err != nil {
+		log.Fatalf("could not create tar: %v", err)
+	}
+
+	resp, err := apiClient.ImageBuild(
+		context.Background(),
+		reader,
+		types.ImageBuildOptions{
+			Remove:      true,
+			ForceRemove: true,
+			Dockerfile:  "Dockerfile",
+			Tags:        []string{*target},
+			Interactive: *interactiveDebug,
+		},
+	)
+	if err != nil {
+		log.Fatalf("could not build image: %v", err)
+	}
+
+	if resp.Body != nil {
+		defer resp.Body.Close()
+	}
+	img := GetImageIDFromBody(resp.Body)
+	if img == "" {
+		fmt.Println("😭 Sorry, that image build failed.")
+	} else {
+		fmt.Println(img)
+	}
+}


### PR DESCRIPTION
Problem: when large builds (spack) fail, we have to start over. Solution: prototype a debug solution that, when a flag -i (for interactive) is added for a custom build entrypoint, we allow a dispatchRun builder command to fail, and still commit the layer. This means we have the changes regardless of the exit code. Note that this is implemented for the Dockerfile builder but not yet buildkit, which has another grpc call that I have not looked at yet. It should be considered a proof of concept.

Putting a PR against my own repository so I can see it! I can't believe this worked, and it was so easy to read the code after months of reading Kubernetes... :laughing: 

![image](https://github.com/user-attachments/assets/62f313b8-1365-4734-934d-8b161c34ffa0)


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- A picture of a cute animal (not mandatory but encouraged)**

Does this count?

![image](https://github.com/user-attachments/assets/497da07a-4cee-4635-b652-f6ce746c0194)

